### PR TITLE
hotfix/Add support for token v1 and v2

### DIFF
--- a/jwt/ABOUT_JWTs.md
+++ b/jwt/ABOUT_JWTs.md
@@ -21,7 +21,8 @@ This module expects the following claims in header and payload:
 | Payload |||
 |--|--|--|
 | *Claim* | *Format* | *Description* |
-| preferred_username | String | Username |
+| unique_name | String | Username (Microsoft Token V1.0) |
+| preferred_username | String | Username (Microsoft Token V2.0, Keycloak)|
 | exp | Int64 (UNIX timestamp) | Expiration date |
 
 


### PR DESCRIPTION
Add support for Microsoft Entra ID JWT v1 _and_ v2. 

Corresponding 'username' has different key depending on version- 'unique_name' for v1 and 'preferred name' for v2.